### PR TITLE
Add Support To Download Playlist From A Playlist Video

### DIFF
--- a/youtube_pl_downloader.py
+++ b/youtube_pl_downloader.py
@@ -56,8 +56,8 @@ def save(url, filename):
 
 def get_available_title(n):
     while True:
-        fname = '{}.mp4'.format(n)
-        if not os.path.isfile(get_abs_filepath(fname)):
+        fname = get_abs_filepath('{}.mp4'.format(n))
+        if not os.path.isfile(fname):
             return fname
         n += 1
 
@@ -90,8 +90,16 @@ def download(video_list):
         print('-'*15)
 
 
+def get_playlist_url(url):
+    a = re.findall('(?<=list=).*', url)
+    id = a[0].split('&')[0]
+    return 'https://www.youtube.com/playlist?list={}'.format(id)
+
+
 def main():
-    vid_list = list(get_videos_href(input('Enter playlist url: ')))
+    url = input('Enter playlist url: ')
+    play_url = get_playlist_url(url)
+    vid_list = list(get_videos_href(play_url))
     download(vid_list)
 
 


### PR DESCRIPTION
It provides functionality to download the entire playlist even when the user inputs URI of a video belonging to the playlist.  
  
For example:  
[https://www.youtube.com/watch?v=1id6ERvfozo&list=PLy7NrYWoggjxKDRWLqkd4Kbt84XEerHhB](https://www.youtube.com/watch?v=1id6ERvfozo&list=PLy7NrYWoggjxKDRWLqkd4Kbt84XEerHhB)  
this URI as an input will download the entire playlist and not raise any error.  




It also adds a inline argument for the user to provide a directory where the videos should be stored (the directory must exist).